### PR TITLE
Feature/defaults helpers irq protection

### DIFF
--- a/src/rfm69_rp2040_interface.c
+++ b/src/rfm69_rp2040_interface.c
@@ -644,7 +644,7 @@ bool rfm69_broadcast_address_set(rfm69_context_t *rfm, uint8_t address) {
     );
 }
 
-bool rfm69_sync_value_set(rfm69_context_t *rfm, uint8_t *value, uint8_t size) {
+bool rfm69_sync_value_set(rfm69_context_t *rfm, const uint8_t *value, uint8_t size) {
     if (!rfm69_write(rfm, RFM69_REG_SYNC_VALUE_1, value, size))
 		return false;
 

--- a/src/rfm69_rp2040_interface.c
+++ b/src/rfm69_rp2040_interface.c
@@ -50,7 +50,7 @@ bool rfm69_init(
 	rfm->pa_level = 0xFF;
 	rfm->pa_mode = RFM69_PA_MODE_PA0;
 	rfm->ocp_trim = RFM69_OCP_TRIM_DEFAULT;
-	rfm->address = 0;
+	rfm->address = RFM69_DEFAULT_ADDR;
 
     // Per documentation we leave RST pin floating for at least
     // 10 ms on startup. No harm in waiting 10ms here to
@@ -74,11 +74,10 @@ bool rfm69_init(
 	}
 
 	rfm69_data_mode_set(rfm, RFM69_DATA_MODE_PACKET);
-
-	rfm69_power_level_set(rfm, 13);
-	rfm69_rssi_threshold_set(rfm, 0xE4); // recommended default
+	rfm69_power_level_set(rfm, RFM69_DEFAULT_POWER_LEVEL);
+	rfm69_rssi_threshold_set(rfm, RFM69_DEFAULT_RSSI_THRESHOLD);
 	rfm69_tx_start_condition_set(rfm, RFM69_TX_FIFO_NOT_EMPTY);
-	rfm69_broadcast_address_set(rfm, 0xFF); 
+	rfm69_broadcast_address_set(rfm, RFM69_DEFAULT_BROADCAST_ADDR);
 	rfm69_address_filter_set(rfm, RFM69_FILTER_NODE_BROADCAST);
 
 	// You have no idea how important this is and how odd
@@ -86,8 +85,7 @@ bool rfm69_init(
 	rfm69_dagc_set(rfm, RFM69_DAGC_IMPROVED_0);
 
 	//Set sync value (essentially functions as subnet)
-	uint8_t sync[3] = {0x01, 0x01, 0x01};
-	rfm69_sync_value_set(rfm, sync, 3);
+	rfm69_sync_value_set(rfm, RFM69_DEFAULT_SYNC_WORD, RFM69_DEFAULT_SYNC_WORD_LEN);
 
 	success = true;
 RETURN:

--- a/src/rfm69_rp2040_interface.h
+++ b/src/rfm69_rp2040_interface.h
@@ -34,7 +34,7 @@
 #define RFM69_DEFAULT_POWER_LEVEL    13
 #define RFM69_DEFAULT_SYNC_WORD_LEN  3
 
-const uint8_t RFM69_DEFAULT_SYNC_WORD[8] = {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+static const uint8_t RFM69_DEFAULT_SYNC_WORD[8] = {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
 
 typedef struct _rfm69_context {
     spi_inst_t *spi; // Initialized SPI instance
@@ -232,7 +232,7 @@ bool rfm69_node_address_set(rfm69_context_t *rfm, uint8_t address);
 void rfm69_node_address_get(rfm69_context_t *rfm, uint8_t *address);
 bool rfm69_broadcast_address_set(rfm69_context_t *rfm, uint8_t address);
 
-bool rfm69_sync_value_set(rfm69_context_t *rfm, uint8_t *value, uint8_t size);
+bool rfm69_sync_value_set(rfm69_context_t *rfm, const uint8_t *value, uint8_t size);
 
 bool rfm69_crc_autoclear_set(rfm69_context_t *rfm, bool set);
 

--- a/src/rfm69_rp2040_interface.h
+++ b/src/rfm69_rp2040_interface.h
@@ -33,6 +33,7 @@
 #define RFM69_DEFAULT_RSSI_THRESHOLD 0xE4
 #define RFM69_DEFAULT_POWER_LEVEL    13
 #define RFM69_DEFAULT_SYNC_WORD_LEN  3
+#define RFM69_DEFAULT_PREAMBLE_LEN   3
 
 static const uint8_t RFM69_DEFAULT_SYNC_WORD[8] = {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
 
@@ -151,6 +152,9 @@ bool rfm69_irq2_flag_state(rfm69_context_t *rfm, RFM69_IRQ2_FLAG flag, bool *sta
 // Returns number of bytes written. 
 bool rfm69_frequency_set(rfm69_context_t *rfm, uint32_t frequency);
 
+// Calculate the closest available frequency
+uint32_t rfm69_frequency_compute_closest(uint32_t frequency);
+
 // Reads operating frequency from module.
 // Note - might not reflect set freqency until a mode change.
 // frequency - stores frequency in Hz.
@@ -162,8 +166,11 @@ bool rfm69_frequency_get(rfm69_context_t *rfm, uint32_t *frequency);
 // Note: 0.5 <= 2* Fdev/Bitrate <= 10
 // Beta value should stay within this range per specification.
 bool rfm69_fdev_set(rfm69_context_t *rfm, uint32_t fdev);
+uint32_t rfm69_fdev_compute_closest(uint32_t fdev);
+bool rfm69_fdev_get(rfm69_context_t *rfm, uint32_t* fdev);
 
 bool rfm69_rxbw_set(rfm69_context_t *rfm, RFM69_RXBW_MANTISSA mantissa, uint8_t exponent);
+bool rfm69_rxbw_get(rfm69_context_t *rfm, uint8_t *mantissa, uint8_t *exponent);
 
 // Sets modem bitrate.
 bool rfm69_bitrate_set(rfm69_context_t *rfm,
@@ -226,17 +233,20 @@ bool rfm69_fifo_threshold_set(rfm69_context_t *rfm, uint8_t threshold);
 
 bool rfm69_payload_length_set(rfm69_context_t *rfm, uint8_t length);
 bool rfm69_packet_format_set(rfm69_context_t *rfm, RFM69_PACKET_FORMAT format);
+bool rfm69_packet_format_get(rfm69_context_t *rfm, uint8_t *format);
 
 bool rfm69_address_filter_set(rfm69_context_t *rfm, RFM69_ADDRESS_FILTER filter);
 bool rfm69_node_address_set(rfm69_context_t *rfm, uint8_t address);
-void rfm69_node_address_get(rfm69_context_t *rfm, uint8_t *address);
+bool rfm69_node_address_get(rfm69_context_t *rfm, uint8_t *address);
 bool rfm69_broadcast_address_set(rfm69_context_t *rfm, uint8_t address);
+bool rfm69_broadcast_address_get(rfm69_context_t *rfm, uint8_t *address);
 
 bool rfm69_sync_value_set(rfm69_context_t *rfm, const uint8_t *value, uint8_t size);
 
 bool rfm69_crc_autoclear_set(rfm69_context_t *rfm, bool set);
 
 bool rfm69_dcfree_set(rfm69_context_t *rfm, RFM69_DCFREE_SETTING setting);
+bool rfm69_dcfree_get(rfm69_context_t *rfm, uint8_t *setting);
 bool rfm69_dagc_set(rfm69_context_t *rfm, RFM69_DAGC_SETTING setting);
 
 // Helper functions to configure dio settings in packet mode

--- a/src/rfm69_rp2040_interface.h
+++ b/src/rfm69_rp2040_interface.h
@@ -28,6 +28,14 @@
 
 #include "rfm69_rp2040_definitions.h"
 
+#define RFM69_DEFAULT_BROADCAST_ADDR 0xFF
+#define RFM69_DEFAULT_ADDR           0x00
+#define RFM69_DEFAULT_RSSI_THRESHOLD 0xE4
+#define RFM69_DEFAULT_POWER_LEVEL    13
+#define RFM69_DEFAULT_SYNC_WORD_LEN  3
+
+const uint8_t RFM69_DEFAULT_SYNC_WORD[8] = {0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01};
+
 typedef struct _rfm69_context {
     spi_inst_t *spi; // Initialized SPI instance
     uint8_t pin_cs;


### PR DESCRIPTION
This change exposes the default settings used in the init function, adds some helpful get functions and adds IRQ protection in the critical spi read write section.