### PR TITLE
Feature/add modulation helpers

### DIFF
--- a/src/rp2x_rfm69_interface.c
+++ b/src/rp2x_rfm69_interface.c
@@ -60,6 +60,8 @@ bool rfm69_init(
     gpio_set_dir(config->pin_rst, GPIO_OUT);
     gpio_put(config->pin_rst, 0);
 
+    uint8_t pream = RFM69_DEFAULT_PREAMBLE_LEN;
+    rfm69_write(rfm, RFM69_REG_PREAMBLE_LSB, &pream, 1);
     // Reset and then try to read version register
     // As long as this returns anything other than 0 or 255, this passes.
     // The most common return is 0x24, but I can't guarantee that future
@@ -423,6 +425,29 @@ bool rfm69_modulation_type_get(rfm69_context_t *rfm, uint8_t *type) {
             type,
             RFM69_MODULATION_TYPE_MASK
     );
+}
+
+bool rfm69_modulation_afc_beta(rfm69_context_t *rfm, bool beta_on) {
+    uint8_t beta_mask = 0;
+
+    if (beta_on) {
+        beta_mask = 1 << 5;
+    }
+
+    return rfm69_write_masked(
+            rfm,
+            RFM69_REG_AFC_CTRL,
+            beta_mask,
+            beta_mask 
+    );
+}
+
+bool rfm69_modulation_afc(rfm69_context_t *rfm, uint8_t afc) {
+    return rfm69_write(
+            rfm,
+            RFM69_REG_TEST_AFC,
+            &afc,
+            1);
 }
 
 bool rfm69_modulation_shaping_set(rfm69_context_t *rfm, RFM69_MODULATION_SHAPING shaping) {

--- a/src/rp2x_rfm69_interface.c
+++ b/src/rp2x_rfm69_interface.c
@@ -427,7 +427,7 @@ bool rfm69_modulation_type_get(rfm69_context_t *rfm, uint8_t *type) {
     );
 }
 
-bool rfm69_modulation_afc_beta(rfm69_context_t *rfm, bool beta_on) {
+bool rfm69_modulation_afc_beta_set(rfm69_context_t *rfm, bool beta_on) {
     uint8_t beta_mask = 0;
 
     if (beta_on) {
@@ -442,12 +442,37 @@ bool rfm69_modulation_afc_beta(rfm69_context_t *rfm, bool beta_on) {
     );
 }
 
-bool rfm69_modulation_afc(rfm69_context_t *rfm, uint8_t afc) {
+bool rfm69_modulation_afc_beta_get(rfm69_context_t *rfm, bool *beta_on) {
+    uint8_t buf = 0;
+    uint8_t beta_on_mask = 1 << 5;
+
+    bool read_result = rfm69_read_masked(
+                        rfm,
+                        RFM69_REG_AFC_CTRL,
+                        &buf,
+                        beta_on_mask
+    );
+
+    if (!read_result)
+        return false;
+
+    *beta_on = (buf > 0);
+
+    return true;
+}
+
+bool rfm69_modulation_afc_set(rfm69_context_t *rfm, uint8_t afc) {
     return rfm69_write(
             rfm,
             RFM69_REG_TEST_AFC,
             &afc,
             1);
+}
+
+bool rfm69_modulation_afc_get(rfm69_context_t *rfm, uint8_t *afc) {
+    if (!rfm69_read(rfm, RFM69_REG_TEST_AFC, afc, 1)) return false;
+
+    return true;
 }
 
 bool rfm69_modulation_shaping_set(rfm69_context_t *rfm, RFM69_MODULATION_SHAPING shaping) {
@@ -739,11 +764,11 @@ bool rfm69_node_address_set(rfm69_context_t *rfm, uint8_t address) {
     return true;
 }
 
-void rfm69_node_address_get(rfm69_context_t *rfm, uint8_t *address) {
+bool rfm69_node_address_get(rfm69_context_t *rfm, uint8_t *address) {
     if (!rfm69_read( rfm, RFM69_REG_NODE_ADRS, address, 1))
-	return false;
+        return false;
 
-    *address = rfm->address;
+    return true;
 }
 
 bool rfm69_broadcast_address_set(rfm69_context_t *rfm, uint8_t address) {

--- a/src/rp2x_rfm69_interface.h
+++ b/src/rp2x_rfm69_interface.h
@@ -210,6 +210,9 @@ bool rfm69_modulation_type_get(rfm69_context_t *rfm, uint8_t *type);
 bool rfm69_modulation_shaping_set(rfm69_context_t *rfm, RFM69_MODULATION_SHAPING shaping);
 bool rfm69_modulation_shaping_get(rfm69_context_t *rfm, uint8_t *shaping);
 
+bool rfm69_modulation_afc_beta(rfm69_context_t *rfm, bool beta_on);
+bool rfm69_modulation_afc(rfm69_context_t *rfm, uint8_t afc);
+
 // Read value of last RSSI measurment
 bool rfm69_rssi_measurment_get(rfm69_context_t *rfm, int16_t *rssi);
 

--- a/src/rp2x_rfm69_interface.h
+++ b/src/rp2x_rfm69_interface.h
@@ -210,8 +210,13 @@ bool rfm69_modulation_type_get(rfm69_context_t *rfm, uint8_t *type);
 bool rfm69_modulation_shaping_set(rfm69_context_t *rfm, RFM69_MODULATION_SHAPING shaping);
 bool rfm69_modulation_shaping_get(rfm69_context_t *rfm, uint8_t *shaping);
 
-bool rfm69_modulation_afc_beta(rfm69_context_t *rfm, bool beta_on);
-bool rfm69_modulation_afc(rfm69_context_t *rfm, uint8_t afc);
+// Turn on afc
+bool rfm69_modulation_afc_beta_set(rfm69_context_t *rfm, bool beta_on);
+bool rfm69_modulation_afc_beta_get(rfm69_context_t *rfm, bool *beta_on);
+
+// Set the afc step
+bool rfm69_modulation_afc_set(rfm69_context_t *rfm, uint8_t afc);
+bool rfm69_modulation_afc_get(rfm69_context_t *rfm, uint8_t *afc);
 
 // Read value of last RSSI measurment
 bool rfm69_rssi_measurment_get(rfm69_context_t *rfm, int16_t *rssi);
@@ -253,7 +258,7 @@ bool rfm69_node_address_set(rfm69_context_t *rfm, uint8_t address);
 
 // No return because it simply returns the cached value from previous set
 // Only valid after init
-void rfm69_node_address_get(rfm69_context_t *rfm, uint8_t *address);
+bool rfm69_node_address_get(rfm69_context_t *rfm, uint8_t *address);
 bool rfm69_broadcast_address_set(rfm69_context_t *rfm, uint8_t address);
 bool rfm69_broadcast_address_get(rfm69_context_t *rfm, uint8_t *address);
 


### PR DESCRIPTION
Make sure that the default preamble length actually get set, which makes it possible for one to change the default.

Fix the get node address, did not properly read out the result, and missing return type.

Add some helpers to set afc_on and afc step. 